### PR TITLE
Refix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ void loop() {
   unsigned long m = millis();
   if(m - secondsTimer > 1000L){
     secondsTimer = m;
-    mppt.ping();  // send oing every second
+    mppt.ping();  // send ping every second
   }
 }
 


### PR DESCRIPTION
Refix typo in README.





may have gotten accidentally changed back cause I think I already submitted a PR for this.